### PR TITLE
Fixed Issue #15: No crash anymore if not using HM IP

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ function rpcType(payload, paramset) {
 function findIface(address) {
     let iface = null;
     Object.keys(devices).forEach(i => {
-        if (devices[i][address]) {
+        if (devices[i] && devices[i][address]) {
             iface = i;
         }
     });


### PR DESCRIPTION
Gibt sicher besser fixes, aber so funkiontiert bei mir hm2mqtt wieder, da ich kein hmip habe. Wieso es lange Zeit funktionierte, bleibt unbekannt.