### PR TITLE
Allow configuration by env variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 const pkg = require('./package.json');
 
 module.exports = require('yargs')
+    .env('HM2MQTT')
     .usage(pkg.name + ' ' + pkg.version + '\n' + pkg.description + '\n\nUsage: $0 [options]')
     .describe('verbosity', 'possible values: "error", "warn", "info", "debug"')
     .describe('name', 'instance name. used as mqtt client id and as prefix for connected topic')


### PR DESCRIPTION
See [yargs documentation](https://github.com/yargs/yargs/blob/master/docs/api.md#envprefix).

Using bash, setting an environmental variable `HM2MQTT_VERBOSITY=debug` would be equal to parameter `-v debug` when calling the script. This allows easier configuration in Docker.